### PR TITLE
Windows native build support

### DIFF
--- a/snappy-sys/Cargo.toml
+++ b/snappy-sys/Cargo.toml
@@ -13,4 +13,6 @@ libc = "0.2"
 
 [build-dependencies]
 pkg-config = "0.3.7"
+cc = "1"
 cmake = "0.1"
+

--- a/snappy-sys/Cargo.toml
+++ b/snappy-sys/Cargo.toml
@@ -13,6 +13,4 @@ libc = "0.2"
 
 [build-dependencies]
 pkg-config = "0.3.7"
-cc = "1"
 cmake = "0.1"
-

--- a/snappy-sys/build.rs
+++ b/snappy-sys/build.rs
@@ -39,7 +39,7 @@ fn configure_snappy(want_static: bool) -> bool {
 fn build_snappy() {
     let out_dir = PathBuf::from(&env::var("OUT_DIR").unwrap());
 
-    let cc = cc::Build::new().get_compiler();
+    let cc = cc::Build::new().cpp(true).get_compiler();
     let mut cflags = OsString::new();
     for arg in cc.args() {
         cflags.push(arg);
@@ -53,7 +53,6 @@ fn build_snappy() {
     println!("cargo:rustc-link-lib=static=snappy");
     println!("cargo:rustc-link-search=native={}", out_dir.join("lib").to_string_lossy());
     println!("cargo:root={}", out_dir.to_string_lossy());
-    configure_stdcpp();
 }
 
 fn configure_stdcpp() {

--- a/snappy-sys/build.rs
+++ b/snappy-sys/build.rs
@@ -45,13 +45,13 @@ fn build_snappy() {
         cflags.push(arg);
         cflags.push(" ");
     }
-    cmake::Config::new("snappy")
+    let output = cmake::Config::new("snappy")
         .env("CC", cc.path())
         .env("CFLAGS", cflags)
         .env("CMAKE_BUILD_TYPE", "static")
         .build();
     println!("cargo:rustc-link-lib=static=snappy");
-    println!("cargo:rustc-link-search=native={}", out_dir.join("lib").to_string_lossy());
+    println!("cargo:rustc-link-search=native={}", output.display());
     println!("cargo:root={}", out_dir.to_string_lossy());
 }
 

--- a/snappy-sys/build.rs
+++ b/snappy-sys/build.rs
@@ -51,7 +51,7 @@ fn build_snappy() {
         .env("CMAKE_BUILD_TYPE", "static")
         .build();
     println!("cargo:rustc-link-lib=static=snappy");
-    println!("cargo:rustc-link-search={}", out_dir.join("lib").to_string_lossy());
+    println!("cargo:rustc-link-search=native={}", out_dir.join("lib").to_string_lossy());
     println!("cargo:root={}", out_dir.to_string_lossy());
     configure_stdcpp();
 }

--- a/snappy-sys/build.rs
+++ b/snappy-sys/build.rs
@@ -3,35 +3,95 @@ extern crate cmake;
 
 use std::env;
 use std::fs;
-
-use cmake::Config;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 
 fn main() {
-    let src = env::current_dir().unwrap().join("snappy");
-    let dst = Config::new("snappy").build_target("snappy").build();
-    let mut build = dst.join("build");
-    let stub = build.join("snappy-stubs-public.h");
-    if cfg!(target_os = "windows") {
-        let profile = match &*env::var("PROFILE").unwrap_or("debug".to_owned()) {
-            "bench" | "release" => "Release",
-            _ => "Debug",
-        };
-        build = build.join(profile);
+    let want_static = env::var("SNAPPY_SYS_STATIC").unwrap_or(String::new()) == "1";
+    let from_source = env::var("SNAPPY_SYS_STATIC_FROM_SOURCE").unwrap_or(String::new()) == "1";
+    if !from_source && configure_snappy(want_static) {
+        return;
     }
-    println!("cargo:root={}", build.display());
+    build_snappy();
+}
+
+fn configure_snappy(want_static: bool) -> bool {
+    // ~ try pkg_config first
+    if pkg_config::probe_library("snappy").is_ok() {
+        return true;
+    }
+    // ~ then try search in statically predefined directories
+    let libsnappy_file = if want_static { "libsnappy.a" } else { "libsnappy.so" };
+    if let Some(path) = first_path_with_file(libsnappy_file) {
+        if want_static {
+            println!("cargo:rustc-link-search={}", path);
+            println!("cargo:rustc-link-lib=static=snappy");
+            configure_stdcpp();
+        } else {
+            println!("cargo:rustc-link-search=native={}", path);
+            println!("cargo:rustc-link-lib=dylib=snappy");
+        }
+        return true;
+    }
+    return false;
+}
+
+fn build_snappy() {
+    let out_dir = PathBuf::from(&env::var("OUT_DIR").unwrap());
+
+    let cc = cc::Build::new().get_compiler();
+    let mut cflags = OsString::new();
+    for arg in cc.args() {
+        cflags.push(arg);
+        cflags.push(" ");
+    }
+    cmake::Config::new("snappy")
+        .env("CC", cc.path())
+        .env("CFLAGS", cflags)
+        .env("CMAKE_BUILD_TYPE", "static")
+        .build();
     println!("cargo:rustc-link-lib=static=snappy");
-    println!("cargo:rustc-link-search=native={}", build.display());
-    fs::copy(src.join("snappy.h"), build.join("snappy.h")).unwrap();
-    if cfg!(target_os = "windows") {
-        fs::copy(stub, build.join("snappy-stubs-public.h")).unwrap();
-    }
+    println!("cargo:rustc-link-search={}", out_dir.join("lib").to_string_lossy());
+    println!("cargo:root={}", out_dir.to_string_lossy());
     configure_stdcpp();
 }
 
 fn configure_stdcpp() {
-    // From: https://github.com/alexcrichton/gcc-rs/blob/master/src/lib.rs
+    // From: https://github.com/alexcrichton/cc-rs/blob/master/src/lib.rs
     let target = env::var("TARGET").unwrap();
-    let cpp = if target.contains("darwin") { "c++" } else { "stdc++" };
-    println!("cargo:rustc-link-lib={}", cpp);
+    let cpp = if target.contains("darwin") {
+        Some("c++")
+    } else if target.contains("windows") {
+        None
+    } else {
+        Some("stdc++")
+    };
+    if let Some(cpp) = cpp {
+        println!("cargo:rustc-link-lib={}", cpp);
+    }
 }
 
+fn first_path_with_file(file: &str) -> Option<String> {
+    // we want to look in LD_LIBRARY_PATH and then some default folders
+    if let Some(ld_path) = env::var_os("LD_LIBRARY_PATH") {
+        for p in env::split_paths(&ld_path) {
+            if is_file_in(file, &p) {
+                return p.to_str().map(|s| String::from(s))
+            }
+        }
+    }
+    for p in vec!["/usr/lib","/usr/local/lib"] {
+        if is_file_in(file, &Path::new(p)) {
+            return Some(String::from(p))
+        }
+    }
+    return None
+}
+
+fn is_file_in(file: &str, folder: &Path) -> bool {
+    let full = folder.join(file);
+    match fs::metadata(full) {
+        Ok(ref found) if found.is_file() => true,
+        _ => false
+    }
+}

--- a/snappy-sys/build.rs
+++ b/snappy-sys/build.rs
@@ -57,6 +57,7 @@ fn build_snappy() {
     println!("cargo:rustc-link-search=native={}/lib", output.display());
     println!("cargo:rustc-link-search=native={}/lib64", output.display());
     println!("cargo:root={}", out_dir.to_string_lossy());
+    configure_stdcpp();
 }
 
 fn configure_stdcpp() {

--- a/snappy-sys/build.rs
+++ b/snappy-sys/build.rs
@@ -3,60 +3,28 @@ extern crate cmake;
 
 use std::env;
 use std::fs;
-use std::ffi::OsString;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+
+use cmake::Config;
 
 fn main() {
-    let want_static = env::var("SNAPPY_SYS_STATIC").unwrap_or(String::new()) == "1";
-    let from_source = env::var("SNAPPY_SYS_STATIC_FROM_SOURCE").unwrap_or(String::new()) == "1";
-    if !from_source && configure_snappy(want_static) {
-        return;
+    let src = env::current_dir().unwrap().join("snappy");
+    let dst = Config::new("snappy").build_target("snappy").build();
+    let mut build = dst.join("build");
+    let stub = build.join("snappy-stubs-public.h");
+    if cfg!(target_os = "windows") {
+        let profile = match &*env::var("PROFILE").unwrap_or("debug".to_owned()) {
+            "bench" | "release" => "Release",
+            _ => "Debug",
+        };
+        build = build.join(profile);
     }
-    build_snappy();
-}
-
-fn configure_snappy(want_static: bool) -> bool {
-    // ~ try pkg_config first
-    if pkg_config::probe_library("snappy").is_ok() {
-        return true;
-    }
-    // ~ then try search in statically predefined directories
-    let libsnappy_file = if want_static { "libsnappy.a" } else { "libsnappy.so" };
-    if let Some(path) = first_path_with_file(libsnappy_file) {
-        if want_static {
-            println!("cargo:rustc-link-search={}", path);
-            println!("cargo:rustc-link-lib=static=snappy");
-            configure_stdcpp();
-        } else {
-            println!("cargo:rustc-link-search=native={}", path);
-            println!("cargo:rustc-link-lib=dylib=snappy");
-        }
-        return true;
-    }
-    return false;
-}
-
-fn build_snappy() {
-    let out_dir = PathBuf::from(&env::var("OUT_DIR").unwrap());
-
-    let cc = cc::Build::new().cpp(true).get_compiler();
-    let mut cflags = OsString::new();
-    for arg in cc.args() {
-        cflags.push(arg);
-        cflags.push(" ");
-    }
-    let output = cmake::Config::new("snappy")
-        .env("CC", cc.path())
-        .env("CFLAGS", cflags)
-        .static_crt(true)
-        .build();
-    Command::new("make").current_dir(&output).status().unwrap();
+    println!("cargo:root={}", build.display());
     println!("cargo:rustc-link-lib=static=snappy");
-    // On some machines, we see lib, on other machines, we see lib64. Add both:
-    println!("cargo:rustc-link-search=native={}/lib", output.display());
-    println!("cargo:rustc-link-search=native={}/lib64", output.display());
-    println!("cargo:root={}", out_dir.to_string_lossy());
+    println!("cargo:rustc-link-search=native={}", build.display());
+    fs::copy(src.join("snappy.h"), build.join("snappy.h")).unwrap();
+    if cfg!(target_os = "windows") {
+        fs::copy(stub, build.join("snappy-stubs-public.h")).unwrap();
+    }
     configure_stdcpp();
 }
 
@@ -72,30 +40,5 @@ fn configure_stdcpp() {
     };
     if let Some(cpp) = cpp {
         println!("cargo:rustc-link-lib={}", cpp);
-    }
-}
-
-fn first_path_with_file(file: &str) -> Option<String> {
-    // we want to look in LD_LIBRARY_PATH and then some default folders
-    if let Some(ld_path) = env::var_os("LD_LIBRARY_PATH") {
-        for p in env::split_paths(&ld_path) {
-            if is_file_in(file, &p) {
-                return p.to_str().map(|s| String::from(s))
-            }
-        }
-    }
-    for p in vec!["/usr/lib","/usr/local/lib"] {
-        if is_file_in(file, &Path::new(p)) {
-            return Some(String::from(p))
-        }
-    }
-    return None
-}
-
-fn is_file_in(file: &str, folder: &Path) -> bool {
-    let full = folder.join(file);
-    match fs::metadata(full) {
-        Ok(ref found) if found.is_file() => true,
-        _ => false
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,7 @@ use libc::size_t;
 use snappy_sys::*;
 
 pub fn validate_compressed_buffer(src: &[u8]) -> bool {
-    unsafe {
-        snappy_validate_compressed_buffer(src.as_ptr(), src.len() as size_t) == 0
-    }
+    unsafe { snappy_validate_compressed_buffer(src.as_ptr(), src.len() as size_t) == 0 }
 }
 
 pub fn compress(src: &[u8]) -> Vec<u8> {
@@ -58,8 +56,8 @@ pub fn uncompress_to(src: &[u8], dst: &mut Vec<u8>) -> Result<usize, ()> {
 
 #[cfg(test)]
 mod tests {
-    use std::str;
     use super::*;
+    use std::str;
 
     #[test]
     fn valid() {
@@ -90,7 +88,9 @@ mod tests {
     #[test]
     fn uncompress_to_appends() {
         // "This is test"
-        let compressed = &[12, 44, 84, 104, 105, 115, 32, 105, 115, 32, 116, 101, 115, 116];
+        let compressed = &[
+            12, 44, 84, 104, 105, 115, 32, 105, 115, 32, 116, 101, 115, 116,
+        ];
 
         let mut out = vec![b'a', b'b', b'c', b'>'];
         uncompress_to(compressed, &mut out).unwrap();


### PR DESCRIPTION
* Updated Snappy to a recent version
* Used new CMake build system (and cmake crate!) to build package
* Removed autotools/shell dependency
* Enabled building on MSVC toolchain for Windows.

# For Other OS's

Nothing should change. You just need CMake installed to build the lib.

# Reproduction on Windows

I first installed [Visual Studio Code Insiders and Build Tools for Visual Studio 2019.](https://visualstudio.microsoft.com/downloads/). 

For the build tools I installed "C/C++ Build Tools" with these checked off:

* MSVC v141,
* MSVC v140
* The newest Windows SDK
* C++ modules for v142 Build Tools
* C++/CLI support for v142 Build Tools

Under "Individual Components" I also picked:

* C++/CLI support for v141 Build Tools
* MSVC C++ - VS 2015 build tools
* Windows Universal CRT SDK
* C++ Universal Windows Platform runtime for v142 build tools

I then set up Rustup:

```powershell
scoop install rustup
rustup default stable
rustup component add rustfmt
rustup component add clippy
rustup component add rls
rustup component add rust-analysis
```

In order to properly statically link the CRT I had to add this to `~/.cargo/config`:

```toml
[target.x86_64-pc-windows-msvc]
rustflags = ["-Ctarget-feature=+crt-static"]
```

At that point you should be able to `cargo test` and see it pass.